### PR TITLE
Split Space/action functionality into EnsureApp spoon, add choice menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,19 @@ The application will be automatically moved to the focused space in Mission Cont
 
 You can also use this to create menus and sub-menus of applications as well.
 
-# Known Issues
-
-* In "move" mode it does not end up exactly under the Menu Bar item, particularly when there are several defined
-
 # Installation
 
-This Spoon depends on another Spoon being installed and loaded, [WindowCache](https://github.com/adammillerio/WindowCache.spoon).
+This Spoon depends on two other Spoons being installed, loaded, and configured:
+* [EnsureApp](https://github.com/adammillerio/EnsureApp.spoon).
+    * Example app configurations provided below
+* [WindowCache](https://github.com/adammillerio/WindowCache.spoon)
+    * No configuration needed other than start
 
 ## Automated
 
 MenuBarApps can be automatically installed from my [Spoon Repository](https://github.com/adammillerio/Spoons) via [SpoonInstall](https://www.hammerspoon.org/Spoons/SpoonInstall.html). See the repository README or the SpoonInstall docs for more information.
 
-Example `init.lua` configuration which configures `SpoonInstall` and uses it to install and start WindowCache and MenuBarApps:
+Example `init.lua` configuration which configures `SpoonInstall` and uses it to install and start EnsureApp and MenuBarApps:
 
 ```lua
 hs.loadSpoon("SpoonInstall")
@@ -34,12 +34,16 @@ spoon.SpoonInstall.repos.adammillerio = {
 
 spoon.SpoonInstall:andUse("WindowCache", {repo = "adammillerio", start = true})
 
-spoon.SpoonInstall:andUse("MenuBarApps", {
+spoon.SpoonInstall:andUse("EnsureApp", {
+    repo = "adammillerio",
+    start = true,
     config = {
         apps = {
-            {title = "P", app = "Plexamp", action = "move"},
-            {title = "D", app = "Discord", action = "maximize"}, {
-                title = "A",
+            ["Plexamp"] = {app = "Plexamp", action = "move"},
+            ["Discord"] = {app = "Discord", action = "maximize"},
+            ["Reminders"] = {app = "Reminders", action = "maximize"},
+            ["Settings"] = {app = "Settings", action = "move"},
+            ["Arc"] = {
                 app = "Arc",
                 action = "maximize",
                 spacePrecedence = true,
@@ -47,27 +51,31 @@ spoon.SpoonInstall:andUse("MenuBarApps", {
                     menuSection = "File",
                     menuItem = "New Window"
                 }
-            }, {
+            }
+        }
+    }
+})
+
+spoon.SpoonInstall:andUse("MenuBarApps", {
+    repo = "adammillerio",
+    start = true
+    config = {
+        apps = {
+            {title = "P", app = "Plexamp"},
+            {title = "D", app = "Discord"},
+            {title = "A", app = "Arc"}, {
                 title = "M",
-                action = "menu",
                 menu = {
-                    {title = "KeePassXC", app = "KeePassXC", action = "move"},
-                    {title = "Reminders", app = "Reminders", action = "move"}, {
+                    {title = "KeePassXC", app = "KeePassXC"},
+                    {title = "Reminders", app = "Reminders"},
+                    {
                         title = "Misc",
-                        action = "menu",
-                        menu = {
-                            {
-                                title = "Settings",
-                                app = "Settings",
-                                action = "move"
-                            }
-                        }
+                        menu = {{title = "Settings", app = "Settings"}}
                     }
                 }
             }
         }
     },
-    start = true
 })
 ```
 
@@ -84,9 +92,11 @@ These can then be moved around like any other menu bar items.
 
 Download the latest WindowCache release from [here.](https://github.com/adammillerio/Spoons/raw/main/Spoons/MenuBarApps.spoon.zip)
 
+Download the latest EnsureApp release from [here.](https://github.com/adammillerio/Spoons/raw/main/Spoons/EnsureApp.spoon.zip)
+
 Download the latest MenuBarApps release from [here.](https://github.com/adammillerio/Spoons/raw/main/Spoons/MenuBarApps.spoon.zip)
 
-Unzip both and either double click to load the Spoons or place the contents manually in `~/.hammerspoon/Spoons`
+Unzip them all and either double click to load the Spoons or place the contents manually in `~/.hammerspoon/Spoons`
 
 Then load the Spoons in `~/.hammerspoon/init.lua`:
 
@@ -95,14 +105,16 @@ hs.loadSpoon("WindowCache")
 
 hs.spoons.use("WindowCache", {start = true})
 
-hs.loadSpoon("MenuBarApps")
+hs.loadSpoon("EnsureApp")
 
-hs.spoons.use("MenuBarApps", {
+hs.spoons.use("EnsureApp", {
     config = {
         apps = {
-            {title = "P", app = "Plexamp", action = "move"},
-            {title = "D", app = "Discord", action = "maximize"}, {
-                title = "A",
+            ["Plexamp"] = {app = "Plexamp", action = "move"},
+            ["Discord"] = {app = "Discord", action = "maximize"},
+            ["Reminders"] = {app = "Reminders", action = "maximize"},
+            ["Settings"] = {app = "Settings", action = "move"},
+            ["Arc"] = {
                 app = "Arc",
                 action = "maximize",
                 spacePrecedence = true,
@@ -110,27 +122,32 @@ hs.spoons.use("MenuBarApps", {
                     menuSection = "File",
                     menuItem = "New Window"
                 }
-            }, {
+            }
+        }
+    },
+    start = true
+})
+
+hs.loadSpoon("MenuBarApps")
+
+hs.spoons.use("MenuBarApps", {
+    config = {
+        apps = {
+            {title = "P", app = "Plexamp"},
+            {title = "D", app = "Discord"},
+            {title = "A", app = "Arc"}, {
                 title = "M",
-                action = "menu",
                 menu = {
-                    {title = "KeePassXC", app = "KeePassXC", action = "move"},
-                    {title = "Reminders", app = "Reminders", action = "move"}, {
+                    {title = "KeePassXC", app = "KeePassXC"},
+                    {title = "Reminders", app = "Reminders"},
+                    {
                         title = "Misc",
-                        action = "menu",
-                        menu = {
-                            {
-                                title = "Settings",
-                                app = "Settings",
-                                action = "move"
-                            }
-                        }
+                        menu = {{title = "Settings", app = "Settings"}}
                     }
                 }
             }
-        },
-        start = true
-    }
+        }
+    },
+    start = true
 })
 ```
-

--- a/README.md
+++ b/README.md
@@ -61,8 +61,13 @@ spoon.SpoonInstall:andUse("MenuBarApps", {
     start = true
     config = {
         apps = {
-            {title = "P", app = "Plexamp"},
             {title = "D", app = "Discord"},
+            {
+                choice = {
+                    {title = "P", app = "Plexamp"},
+                    {title = "S", app = "Spotify"}
+                }
+            },
             {title = "A", app = "Arc"}, {
                 title = "M",
                 menu = {
@@ -81,8 +86,10 @@ spoon.SpoonInstall:andUse("MenuBarApps", {
 
 This will create three menu bar items:
 
-* Menu Bar with icon "P" which opens the "Plexamp" application and moves it to be under the Menu Bar in the current Space
 * Menu Bar with icon "D" which opens the "Discord" application and maximizes it in the current Space
+* Menu Bar with icon "P" which opens the "Plexamp" application and moves it to be under the Menu Bar in the current Space
+    * If Alt key is pressed when selecting this menu item, it will change to S and open Spotify
+    * Alt key will continue to cycle through choices while pressed
 * Menu Bar with icon "A" which opens a Space-specific instance of the "Arc" application in the current space, using the provided newWindowConfig to identify an application menu selection
 * Menu Bar with icon "M" which opens menu with "KeePassXC", "Reminders", and a "Misc" sub-menu with "Settings".
 
@@ -133,8 +140,13 @@ hs.loadSpoon("MenuBarApps")
 hs.spoons.use("MenuBarApps", {
     config = {
         apps = {
-            {title = "P", app = "Plexamp"},
             {title = "D", app = "Discord"},
+            {
+                choice = {
+                    {title = "P", app = "Plexamp"},
+                    {title = "S", app = "Spotify"}
+                }
+            },
             {title = "A", app = "Arc"}, {
                 title = "M",
                 menu = {

--- a/docs.json
+++ b/docs.json
@@ -1,46 +1,7 @@
 [
   {
     "Constant" : [
-      {
-        "doc" : "Move the window to appear under the menu bar item as if it were a menu.",
-        "stripped_doc" : [
-          "Move the window to appear under the menu bar item as if it were a menu."
-        ],
-        "desc" : "Move the window to appear under the menu bar item as if it were a menu.",
-        "parameters" : [
 
-        ],
-        "notes" : [
-
-        ],
-        "signature" : "MenuBarApps.action.move",
-        "type" : "Constant",
-        "returns" : [
-
-        ],
-        "def" : "MenuBarApps.action.move",
-        "name" : "action"
-      },
-      {
-        "doc" : "Maximize the application on the current space if it is not maximized already.",
-        "stripped_doc" : [
-          "Maximize the application on the current space if it is not maximized already."
-        ],
-        "desc" : "Maximize the application on the current space if it is not maximized already.",
-        "parameters" : [
-
-        ],
-        "notes" : [
-
-        ],
-        "signature" : "MenuBarApps.action.maximize",
-        "type" : "Constant",
-        "returns" : [
-
-        ],
-        "def" : "MenuBarApps.action.maximize",
-        "name" : "action"
-      }
     ],
     "submodules" : [
 
@@ -50,18 +11,17 @@
     ],
     "Variable" : [
       {
-        "doc" : "Table containing each application's name and it's desired configuration. The\nkey of each entry is the name of the App as it appears in the title bar, and\nthe value is a configuration table with the following entries:\n    * title - String with title text to display in the menu bar icon itself\n    * action - String with action to take on window when showing. See constants.",
+        "def" : "MenuBarApps.apps",
         "stripped_doc" : [
           "Table containing each application's name and it's desired configuration. The",
           "key of each entry is the name of the App as it appears in the title bar, and",
           "the value is a configuration table with the following entries:",
           "    * title - String with title text to display in the menu bar icon itself",
+          "    * app - Name of the application in EnsureApp config. ",
           "    * action - String with action to take on window when showing. See constants."
         ],
-        "desc" : "Table containing each application's name and it's desired configuration. The",
-        "parameters" : [
-
-        ],
+        "name" : "apps",
+        "doc" : "Table containing each application's name and it's desired configuration. The\nkey of each entry is the name of the App as it appears in the title bar, and\nthe value is a configuration table with the following entries:\n    * title - String with title text to display in the menu bar icon itself\n    * app - Name of the application in EnsureApp config. \n    * action - String with action to take on window when showing. See constants.",
         "notes" : [
 
         ],
@@ -70,19 +30,19 @@
         "returns" : [
 
         ],
-        "def" : "MenuBarApps.apps",
-        "name" : "apps"
+        "desc" : "Table containing each application's name and it's desired configuration. The",
+        "parameters" : [
+
+        ]
       },
       {
-        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log \nlevel for the messages coming from the Spoon.",
+        "def" : "MenuBarApps.logger",
         "stripped_doc" : [
           "Logger object used within the Spoon. Can be accessed to set the default log ",
           "level for the messages coming from the Spoon."
         ],
-        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log",
-        "parameters" : [
-
-        ],
+        "name" : "logger",
+        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log \nlevel for the messages coming from the Spoon.",
         "notes" : [
 
         ],
@@ -91,18 +51,18 @@
         "returns" : [
 
         ],
-        "def" : "MenuBarApps.logger",
-        "name" : "logger"
+        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log",
+        "parameters" : [
+
+        ]
       },
       {
-        "doc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
+        "def" : "MenuBarApps.logLevel",
         "stripped_doc" : [
           "MenuBarApps specific log level override, see hs.logger.setLogLevel for options."
         ],
-        "desc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
-        "parameters" : [
-
-        ],
+        "name" : "logLevel",
+        "doc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
         "notes" : [
 
         ],
@@ -111,18 +71,18 @@
         "returns" : [
 
         ],
-        "def" : "MenuBarApps.logLevel",
-        "name" : "logLevel"
+        "desc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
+        "parameters" : [
+
+        ]
       },
       {
-        "doc" : "Table containing references to all of the created menu bars.",
+        "def" : "MenuBarApps.menuBars",
         "stripped_doc" : [
           "Table containing references to all of the created menu bars."
         ],
-        "desc" : "Table containing references to all of the created menu bars.",
-        "parameters" : [
-
-        ],
+        "name" : "menuBars",
+        "doc" : "Table containing references to all of the created menu bars.",
         "notes" : [
 
         ],
@@ -131,97 +91,37 @@
         "returns" : [
 
         ],
-        "def" : "MenuBarApps.menuBars",
-        "name" : "menuBars"
-      },
-      {
-        "doc" : "hs.timer for moving an app's first window after being opened via MenuBarApps.\nThis behavior can be disabled by setting disableOpen=true on the app config.",
-        "stripped_doc" : [
-          "hs.timer for moving an app's first window after being opened via MenuBarApps.",
-          "This behavior can be disabled by setting disableOpen=true on the app config."
-        ],
-        "desc" : "hs.timer for moving an app's first window after being opened via MenuBarApps.",
+        "desc" : "Table containing references to all of the created menu bars.",
         "parameters" : [
 
-        ],
-        "notes" : [
-
-        ],
-        "signature" : "MenuBarApps.menuBarOpenTimer",
-        "type" : "Variable",
-        "returns" : [
-
-        ],
-        "def" : "MenuBarApps.menuBarOpenTimer",
-        "name" : "menuBarOpenTimer"
+        ]
       }
     ],
     "stripped_doc" : [
 
     ],
-    "desc" : "Control applications from the macOS Menu Bar",
     "type" : "Module",
     "Deprecated" : [
 
     ],
+    "desc" : "Control applications from the macOS Menu Bar",
     "Constructor" : [
 
     ],
     "doc" : "Control applications from the macOS Menu Bar \n\nDownload: https:\/\/github.com\/adammillerio\/Spoons\/raw\/main\/Spoons\/MenuBarApps.spoon.zip\n\nREADME with Example Usage: [README.md](https:\/\/github.com\/adammillerio\/MenuBarApps.spoon\/blob\/main\/README.md)",
     "items" : [
       {
-        "doc" : "Move the window to appear under the menu bar item as if it were a menu.",
-        "stripped_doc" : [
-          "Move the window to appear under the menu bar item as if it were a menu."
-        ],
-        "desc" : "Move the window to appear under the menu bar item as if it were a menu.",
-        "parameters" : [
-
-        ],
-        "notes" : [
-
-        ],
-        "signature" : "MenuBarApps.action.move",
-        "type" : "Constant",
-        "returns" : [
-
-        ],
-        "def" : "MenuBarApps.action.move",
-        "name" : "action"
-      },
-      {
-        "doc" : "Maximize the application on the current space if it is not maximized already.",
-        "stripped_doc" : [
-          "Maximize the application on the current space if it is not maximized already."
-        ],
-        "desc" : "Maximize the application on the current space if it is not maximized already.",
-        "parameters" : [
-
-        ],
-        "notes" : [
-
-        ],
-        "signature" : "MenuBarApps.action.maximize",
-        "type" : "Constant",
-        "returns" : [
-
-        ],
-        "def" : "MenuBarApps.action.maximize",
-        "name" : "action"
-      },
-      {
-        "doc" : "Table containing each application's name and it's desired configuration. The\nkey of each entry is the name of the App as it appears in the title bar, and\nthe value is a configuration table with the following entries:\n    * title - String with title text to display in the menu bar icon itself\n    * action - String with action to take on window when showing. See constants.",
+        "def" : "MenuBarApps.apps",
         "stripped_doc" : [
           "Table containing each application's name and it's desired configuration. The",
           "key of each entry is the name of the App as it appears in the title bar, and",
           "the value is a configuration table with the following entries:",
           "    * title - String with title text to display in the menu bar icon itself",
+          "    * app - Name of the application in EnsureApp config. ",
           "    * action - String with action to take on window when showing. See constants."
         ],
-        "desc" : "Table containing each application's name and it's desired configuration. The",
-        "parameters" : [
-
-        ],
+        "name" : "apps",
+        "doc" : "Table containing each application's name and it's desired configuration. The\nkey of each entry is the name of the App as it appears in the title bar, and\nthe value is a configuration table with the following entries:\n    * title - String with title text to display in the menu bar icon itself\n    * app - Name of the application in EnsureApp config. \n    * action - String with action to take on window when showing. See constants.",
         "notes" : [
 
         ],
@@ -230,18 +130,18 @@
         "returns" : [
 
         ],
-        "def" : "MenuBarApps.apps",
-        "name" : "apps"
+        "desc" : "Table containing each application's name and it's desired configuration. The",
+        "parameters" : [
+
+        ]
       },
       {
-        "doc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
+        "def" : "MenuBarApps.logLevel",
         "stripped_doc" : [
           "MenuBarApps specific log level override, see hs.logger.setLogLevel for options."
         ],
-        "desc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
-        "parameters" : [
-
-        ],
+        "name" : "logLevel",
+        "doc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
         "notes" : [
 
         ],
@@ -250,19 +150,19 @@
         "returns" : [
 
         ],
-        "def" : "MenuBarApps.logLevel",
-        "name" : "logLevel"
+        "desc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
+        "parameters" : [
+
+        ]
       },
       {
-        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log \nlevel for the messages coming from the Spoon.",
+        "def" : "MenuBarApps.logger",
         "stripped_doc" : [
           "Logger object used within the Spoon. Can be accessed to set the default log ",
           "level for the messages coming from the Spoon."
         ],
-        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log",
-        "parameters" : [
-
-        ],
+        "name" : "logger",
+        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log \nlevel for the messages coming from the Spoon.",
         "notes" : [
 
         ],
@@ -271,39 +171,18 @@
         "returns" : [
 
         ],
-        "def" : "MenuBarApps.logger",
-        "name" : "logger"
-      },
-      {
-        "doc" : "hs.timer for moving an app's first window after being opened via MenuBarApps.\nThis behavior can be disabled by setting disableOpen=true on the app config.",
-        "stripped_doc" : [
-          "hs.timer for moving an app's first window after being opened via MenuBarApps.",
-          "This behavior can be disabled by setting disableOpen=true on the app config."
-        ],
-        "desc" : "hs.timer for moving an app's first window after being opened via MenuBarApps.",
+        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log",
         "parameters" : [
 
-        ],
-        "notes" : [
-
-        ],
-        "signature" : "MenuBarApps.menuBarOpenTimer",
-        "type" : "Variable",
-        "returns" : [
-
-        ],
-        "def" : "MenuBarApps.menuBarOpenTimer",
-        "name" : "menuBarOpenTimer"
+        ]
       },
       {
-        "doc" : "Table containing references to all of the created menu bars.",
+        "def" : "MenuBarApps.menuBars",
         "stripped_doc" : [
           "Table containing references to all of the created menu bars."
         ],
-        "desc" : "Table containing references to all of the created menu bars.",
-        "parameters" : [
-
-        ],
+        "name" : "menuBars",
+        "doc" : "Table containing references to all of the created menu bars.",
         "notes" : [
 
         ],
@@ -312,20 +191,19 @@
         "returns" : [
 
         ],
-        "def" : "MenuBarApps.menuBars",
-        "name" : "menuBars"
+        "desc" : "Table containing references to all of the created menu bars.",
+        "parameters" : [
+
+        ]
       },
       {
-        "doc" : "Spoon initializer method for MenuBarApps.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "def" : "MenuBarApps:init()",
         "stripped_doc" : [
           "Spoon initializer method for MenuBarApps.",
           ""
         ],
-        "desc" : "Spoon initializer method for MenuBarApps.",
-        "parameters" : [
-          " * None",
-          ""
-        ],
+        "name" : "init",
+        "doc" : "Spoon initializer method for MenuBarApps.\n\nParameters:\n * None\n\nReturns:\n * None",
         "notes" : [
 
         ],
@@ -334,20 +212,20 @@
         "returns" : [
           " * None"
         ],
-        "def" : "MenuBarApps:init()",
-        "name" : "init"
+        "desc" : "Spoon initializer method for MenuBarApps.",
+        "parameters" : [
+          " * None",
+          ""
+        ]
       },
       {
-        "doc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "def" : "MenuBarApps:start()",
         "stripped_doc" : [
           "Spoon start method for MenuBarApps. Creates all configured menu bars.",
           ""
         ],
-        "desc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.",
-        "parameters" : [
-          " * None",
-          ""
-        ],
+        "name" : "start",
+        "doc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
         "notes" : [
 
         ],
@@ -356,20 +234,20 @@
         "returns" : [
           " * None"
         ],
-        "def" : "MenuBarApps:start()",
-        "name" : "start"
+        "desc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.",
+        "parameters" : [
+          " * None",
+          ""
+        ]
       },
       {
-        "doc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "def" : "MenuBarApps:stop()",
         "stripped_doc" : [
           "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
           ""
         ],
-        "desc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
-        "parameters" : [
-          " * None",
-          ""
-        ],
+        "name" : "stop",
+        "doc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
         "notes" : [
 
         ],
@@ -378,8 +256,11 @@
         "returns" : [
           " * None"
         ],
-        "def" : "MenuBarApps:stop()",
-        "name" : "stop"
+        "desc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
+        "parameters" : [
+          " * None",
+          ""
+        ]
       }
     ],
     "Command" : [
@@ -390,16 +271,13 @@
     ],
     "Method" : [
       {
-        "doc" : "Spoon initializer method for MenuBarApps.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "def" : "MenuBarApps:init()",
         "stripped_doc" : [
           "Spoon initializer method for MenuBarApps.",
           ""
         ],
-        "desc" : "Spoon initializer method for MenuBarApps.",
-        "parameters" : [
-          " * None",
-          ""
-        ],
+        "name" : "init",
+        "doc" : "Spoon initializer method for MenuBarApps.\n\nParameters:\n * None\n\nReturns:\n * None",
         "notes" : [
 
         ],
@@ -408,20 +286,20 @@
         "returns" : [
           " * None"
         ],
-        "def" : "MenuBarApps:init()",
-        "name" : "init"
+        "desc" : "Spoon initializer method for MenuBarApps.",
+        "parameters" : [
+          " * None",
+          ""
+        ]
       },
       {
-        "doc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "def" : "MenuBarApps:start()",
         "stripped_doc" : [
           "Spoon start method for MenuBarApps. Creates all configured menu bars.",
           ""
         ],
-        "desc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.",
-        "parameters" : [
-          " * None",
-          ""
-        ],
+        "name" : "start",
+        "doc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
         "notes" : [
 
         ],
@@ -430,20 +308,20 @@
         "returns" : [
           " * None"
         ],
-        "def" : "MenuBarApps:start()",
-        "name" : "start"
+        "desc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.",
+        "parameters" : [
+          " * None",
+          ""
+        ]
       },
       {
-        "doc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "def" : "MenuBarApps:stop()",
         "stripped_doc" : [
           "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
           ""
         ],
-        "desc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
-        "parameters" : [
-          " * None",
-          ""
-        ],
+        "name" : "stop",
+        "doc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
         "notes" : [
 
         ],
@@ -452,8 +330,11 @@
         "returns" : [
           " * None"
         ],
-        "def" : "MenuBarApps:stop()",
-        "name" : "stop"
+        "desc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
+        "parameters" : [
+          " * None",
+          ""
+        ]
       }
     ],
     "name" : "MenuBarApps"

--- a/docs.json
+++ b/docs.json
@@ -11,7 +11,8 @@
     ],
     "Variable" : [
       {
-        "doc" : "Table containing each application's name and it's desired configuration. The\nkey of each entry is the name of the App as it appears in the title bar, and\nthe value is a configuration table with the following entries:\n    * title - String with title text to display in the menu bar icon itself\n    * app - Name of the application in EnsureApp config. \n    * action - String with action to take on window when showing. See constants.",
+        "desc" : "Table containing each application's name and it's desired configuration. The",
+        "def" : "MenuBarApps.apps",
         "stripped_doc" : [
           "Table containing each application's name and it's desired configuration. The",
           "key of each entry is the name of the App as it appears in the title bar, and",
@@ -20,10 +21,7 @@
           "    * app - Name of the application in EnsureApp config. ",
           "    * action - String with action to take on window when showing. See constants."
         ],
-        "parameters" : [
-
-        ],
-        "desc" : "Table containing each application's name and it's desired configuration. The",
+        "doc" : "Table containing each application's name and it's desired configuration. The\nkey of each entry is the name of the App as it appears in the title bar, and\nthe value is a configuration table with the following entries:\n    * title - String with title text to display in the menu bar icon itself\n    * app - Name of the application in EnsureApp config. \n    * action - String with action to take on window when showing. See constants.",
         "notes" : [
 
         ],
@@ -33,18 +31,18 @@
 
         ],
         "name" : "apps",
-        "def" : "MenuBarApps.apps"
+        "parameters" : [
+
+        ]
       },
       {
-        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log \nlevel for the messages coming from the Spoon.",
+        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log",
+        "def" : "MenuBarApps.logger",
         "stripped_doc" : [
           "Logger object used within the Spoon. Can be accessed to set the default log ",
           "level for the messages coming from the Spoon."
         ],
-        "parameters" : [
-
-        ],
-        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log",
+        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log \nlevel for the messages coming from the Spoon.",
         "notes" : [
 
         ],
@@ -54,17 +52,17 @@
 
         ],
         "name" : "logger",
-        "def" : "MenuBarApps.logger"
+        "parameters" : [
+
+        ]
       },
       {
-        "doc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
+        "desc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
+        "def" : "MenuBarApps.logLevel",
         "stripped_doc" : [
           "MenuBarApps specific log level override, see hs.logger.setLogLevel for options."
         ],
-        "parameters" : [
-
-        ],
-        "desc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
+        "doc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
         "notes" : [
 
         ],
@@ -74,17 +72,17 @@
 
         ],
         "name" : "logLevel",
-        "def" : "MenuBarApps.logLevel"
+        "parameters" : [
+
+        ]
       },
       {
-        "doc" : "Table containing references to all of the created menu bars.",
+        "desc" : "Table containing references to all of the created menu bars.",
+        "def" : "MenuBarApps.menuBars",
         "stripped_doc" : [
           "Table containing references to all of the created menu bars."
         ],
-        "parameters" : [
-
-        ],
-        "desc" : "Table containing references to all of the created menu bars.",
+        "doc" : "Table containing references to all of the created menu bars.",
         "notes" : [
 
         ],
@@ -94,33 +92,34 @@
 
         ],
         "name" : "menuBars",
-        "def" : "MenuBarApps.menuBars"
+        "parameters" : [
+
+        ]
       }
     ],
     "stripped_doc" : [
 
     ],
+    "desc" : "Control applications from the macOS Menu Bar",
     "Deprecated" : [
 
     ],
-    "desc" : "Control applications from the macOS Menu Bar",
     "type" : "Module",
     "Constructor" : [
 
     ],
-    "doc" : "Control applications from the macOS Menu Bar \n\nDownload: https:\/\/github.com\/adammillerio\/Spoons\/raw\/main\/Spoons\/MenuBarApps.spoon.zip\n\nREADME with Example Usage: [README.md](https:\/\/github.com\/adammillerio\/MenuBarApps.spoon\/blob\/main\/README.md)",
+    "Field" : [
+
+    ],
     "Method" : [
       {
-        "doc" : "Spoon initializer method for MenuBarApps.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "desc" : "Spoon initializer method for MenuBarApps.",
+        "def" : "MenuBarApps:init()",
         "stripped_doc" : [
           "Spoon initializer method for MenuBarApps.",
           ""
         ],
-        "parameters" : [
-          " * None",
-          ""
-        ],
-        "desc" : "Spoon initializer method for MenuBarApps.",
+        "doc" : "Spoon initializer method for MenuBarApps.\n\nParameters:\n * None\n\nReturns:\n * None",
         "notes" : [
 
         ],
@@ -130,19 +129,19 @@
           " * None"
         ],
         "name" : "init",
-        "def" : "MenuBarApps:init()"
+        "parameters" : [
+          " * None",
+          ""
+        ]
       },
       {
-        "doc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "desc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.",
+        "def" : "MenuBarApps:start()",
         "stripped_doc" : [
           "Spoon start method for MenuBarApps. Creates all configured menu bars.",
           ""
         ],
-        "parameters" : [
-          " * None",
-          ""
-        ],
-        "desc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.",
+        "doc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
         "notes" : [
 
         ],
@@ -152,19 +151,19 @@
           " * None"
         ],
         "name" : "start",
-        "def" : "MenuBarApps:start()"
+        "parameters" : [
+          " * None",
+          ""
+        ]
       },
       {
-        "doc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "desc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
+        "def" : "MenuBarApps:stop()",
         "stripped_doc" : [
           "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
           ""
         ],
-        "parameters" : [
-          " * None",
-          ""
-        ],
-        "desc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
+        "doc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
         "notes" : [
 
         ],
@@ -174,18 +173,19 @@
           " * None"
         ],
         "name" : "stop",
-        "def" : "MenuBarApps:stop()"
+        "parameters" : [
+          " * None",
+          ""
+        ]
       }
     ],
     "Command" : [
 
     ],
-    "Field" : [
-
-    ],
     "items" : [
       {
-        "doc" : "Table containing each application's name and it's desired configuration. The\nkey of each entry is the name of the App as it appears in the title bar, and\nthe value is a configuration table with the following entries:\n    * title - String with title text to display in the menu bar icon itself\n    * app - Name of the application in EnsureApp config. \n    * action - String with action to take on window when showing. See constants.",
+        "desc" : "Table containing each application's name and it's desired configuration. The",
+        "def" : "MenuBarApps.apps",
         "stripped_doc" : [
           "Table containing each application's name and it's desired configuration. The",
           "key of each entry is the name of the App as it appears in the title bar, and",
@@ -194,10 +194,7 @@
           "    * app - Name of the application in EnsureApp config. ",
           "    * action - String with action to take on window when showing. See constants."
         ],
-        "parameters" : [
-
-        ],
-        "desc" : "Table containing each application's name and it's desired configuration. The",
+        "doc" : "Table containing each application's name and it's desired configuration. The\nkey of each entry is the name of the App as it appears in the title bar, and\nthe value is a configuration table with the following entries:\n    * title - String with title text to display in the menu bar icon itself\n    * app - Name of the application in EnsureApp config. \n    * action - String with action to take on window when showing. See constants.",
         "notes" : [
 
         ],
@@ -207,17 +204,17 @@
 
         ],
         "name" : "apps",
-        "def" : "MenuBarApps.apps"
+        "parameters" : [
+
+        ]
       },
       {
-        "doc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
+        "desc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
+        "def" : "MenuBarApps.logLevel",
         "stripped_doc" : [
           "MenuBarApps specific log level override, see hs.logger.setLogLevel for options."
         ],
-        "parameters" : [
-
-        ],
-        "desc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
+        "doc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
         "notes" : [
 
         ],
@@ -227,18 +224,18 @@
 
         ],
         "name" : "logLevel",
-        "def" : "MenuBarApps.logLevel"
+        "parameters" : [
+
+        ]
       },
       {
-        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log \nlevel for the messages coming from the Spoon.",
+        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log",
+        "def" : "MenuBarApps.logger",
         "stripped_doc" : [
           "Logger object used within the Spoon. Can be accessed to set the default log ",
           "level for the messages coming from the Spoon."
         ],
-        "parameters" : [
-
-        ],
-        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log",
+        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log \nlevel for the messages coming from the Spoon.",
         "notes" : [
 
         ],
@@ -248,17 +245,17 @@
 
         ],
         "name" : "logger",
-        "def" : "MenuBarApps.logger"
+        "parameters" : [
+
+        ]
       },
       {
-        "doc" : "Table containing references to all of the created menu bars.",
+        "desc" : "Table containing references to all of the created menu bars.",
+        "def" : "MenuBarApps.menuBars",
         "stripped_doc" : [
           "Table containing references to all of the created menu bars."
         ],
-        "parameters" : [
-
-        ],
-        "desc" : "Table containing references to all of the created menu bars.",
+        "doc" : "Table containing references to all of the created menu bars.",
         "notes" : [
 
         ],
@@ -268,19 +265,18 @@
 
         ],
         "name" : "menuBars",
-        "def" : "MenuBarApps.menuBars"
+        "parameters" : [
+
+        ]
       },
       {
-        "doc" : "Spoon initializer method for MenuBarApps.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "desc" : "Spoon initializer method for MenuBarApps.",
+        "def" : "MenuBarApps:init()",
         "stripped_doc" : [
           "Spoon initializer method for MenuBarApps.",
           ""
         ],
-        "parameters" : [
-          " * None",
-          ""
-        ],
-        "desc" : "Spoon initializer method for MenuBarApps.",
+        "doc" : "Spoon initializer method for MenuBarApps.\n\nParameters:\n * None\n\nReturns:\n * None",
         "notes" : [
 
         ],
@@ -290,19 +286,19 @@
           " * None"
         ],
         "name" : "init",
-        "def" : "MenuBarApps:init()"
+        "parameters" : [
+          " * None",
+          ""
+        ]
       },
       {
-        "doc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "desc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.",
+        "def" : "MenuBarApps:start()",
         "stripped_doc" : [
           "Spoon start method for MenuBarApps. Creates all configured menu bars.",
           ""
         ],
-        "parameters" : [
-          " * None",
-          ""
-        ],
-        "desc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.",
+        "doc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
         "notes" : [
 
         ],
@@ -312,19 +308,19 @@
           " * None"
         ],
         "name" : "start",
-        "def" : "MenuBarApps:start()"
+        "parameters" : [
+          " * None",
+          ""
+        ]
       },
       {
-        "doc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "desc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
+        "def" : "MenuBarApps:stop()",
         "stripped_doc" : [
           "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
           ""
         ],
-        "parameters" : [
-          " * None",
-          ""
-        ],
-        "desc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
+        "doc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
         "notes" : [
 
         ],
@@ -334,9 +330,13 @@
           " * None"
         ],
         "name" : "stop",
-        "def" : "MenuBarApps:stop()"
+        "parameters" : [
+          " * None",
+          ""
+        ]
       }
     ],
+    "doc" : "Control applications from the macOS Menu Bar \n\nDownload: https:\/\/github.com\/adammillerio\/Spoons\/raw\/main\/Spoons\/MenuBarApps.spoon.zip\n\nREADME with Example Usage: [README.md](https:\/\/github.com\/adammillerio\/MenuBarApps.spoon\/blob\/main\/README.md)",
     "name" : "MenuBarApps"
   }
 ]

--- a/docs.json
+++ b/docs.json
@@ -11,7 +11,7 @@
     ],
     "Variable" : [
       {
-        "def" : "MenuBarApps.apps",
+        "doc" : "Table containing each application's name and it's desired configuration. The\nkey of each entry is the name of the App as it appears in the title bar, and\nthe value is a configuration table with the following entries:\n    * title - String with title text to display in the menu bar icon itself\n    * app - Name of the application in EnsureApp config. \n    * action - String with action to take on window when showing. See constants.",
         "stripped_doc" : [
           "Table containing each application's name and it's desired configuration. The",
           "key of each entry is the name of the App as it appears in the title bar, and",
@@ -20,8 +20,10 @@
           "    * app - Name of the application in EnsureApp config. ",
           "    * action - String with action to take on window when showing. See constants."
         ],
-        "name" : "apps",
-        "doc" : "Table containing each application's name and it's desired configuration. The\nkey of each entry is the name of the App as it appears in the title bar, and\nthe value is a configuration table with the following entries:\n    * title - String with title text to display in the menu bar icon itself\n    * app - Name of the application in EnsureApp config. \n    * action - String with action to take on window when showing. See constants.",
+        "parameters" : [
+
+        ],
+        "desc" : "Table containing each application's name and it's desired configuration. The",
         "notes" : [
 
         ],
@@ -30,19 +32,19 @@
         "returns" : [
 
         ],
-        "desc" : "Table containing each application's name and it's desired configuration. The",
-        "parameters" : [
-
-        ]
+        "name" : "apps",
+        "def" : "MenuBarApps.apps"
       },
       {
-        "def" : "MenuBarApps.logger",
+        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log \nlevel for the messages coming from the Spoon.",
         "stripped_doc" : [
           "Logger object used within the Spoon. Can be accessed to set the default log ",
           "level for the messages coming from the Spoon."
         ],
-        "name" : "logger",
-        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log \nlevel for the messages coming from the Spoon.",
+        "parameters" : [
+
+        ],
+        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log",
         "notes" : [
 
         ],
@@ -51,18 +53,18 @@
         "returns" : [
 
         ],
-        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log",
-        "parameters" : [
-
-        ]
+        "name" : "logger",
+        "def" : "MenuBarApps.logger"
       },
       {
-        "def" : "MenuBarApps.logLevel",
+        "doc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
         "stripped_doc" : [
           "MenuBarApps specific log level override, see hs.logger.setLogLevel for options."
         ],
-        "name" : "logLevel",
-        "doc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
+        "parameters" : [
+
+        ],
+        "desc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
         "notes" : [
 
         ],
@@ -71,18 +73,18 @@
         "returns" : [
 
         ],
-        "desc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
-        "parameters" : [
-
-        ]
+        "name" : "logLevel",
+        "def" : "MenuBarApps.logLevel"
       },
       {
-        "def" : "MenuBarApps.menuBars",
+        "doc" : "Table containing references to all of the created menu bars.",
         "stripped_doc" : [
           "Table containing references to all of the created menu bars."
         ],
-        "name" : "menuBars",
-        "doc" : "Table containing references to all of the created menu bars.",
+        "parameters" : [
+
+        ],
+        "desc" : "Table containing references to all of the created menu bars.",
         "notes" : [
 
         ],
@@ -91,119 +93,34 @@
         "returns" : [
 
         ],
-        "desc" : "Table containing references to all of the created menu bars.",
-        "parameters" : [
-
-        ]
+        "name" : "menuBars",
+        "def" : "MenuBarApps.menuBars"
       }
     ],
     "stripped_doc" : [
 
     ],
-    "type" : "Module",
     "Deprecated" : [
 
     ],
     "desc" : "Control applications from the macOS Menu Bar",
+    "type" : "Module",
     "Constructor" : [
 
     ],
     "doc" : "Control applications from the macOS Menu Bar \n\nDownload: https:\/\/github.com\/adammillerio\/Spoons\/raw\/main\/Spoons\/MenuBarApps.spoon.zip\n\nREADME with Example Usage: [README.md](https:\/\/github.com\/adammillerio\/MenuBarApps.spoon\/blob\/main\/README.md)",
-    "items" : [
+    "Method" : [
       {
-        "def" : "MenuBarApps.apps",
-        "stripped_doc" : [
-          "Table containing each application's name and it's desired configuration. The",
-          "key of each entry is the name of the App as it appears in the title bar, and",
-          "the value is a configuration table with the following entries:",
-          "    * title - String with title text to display in the menu bar icon itself",
-          "    * app - Name of the application in EnsureApp config. ",
-          "    * action - String with action to take on window when showing. See constants."
-        ],
-        "name" : "apps",
-        "doc" : "Table containing each application's name and it's desired configuration. The\nkey of each entry is the name of the App as it appears in the title bar, and\nthe value is a configuration table with the following entries:\n    * title - String with title text to display in the menu bar icon itself\n    * app - Name of the application in EnsureApp config. \n    * action - String with action to take on window when showing. See constants.",
-        "notes" : [
-
-        ],
-        "signature" : "MenuBarApps.apps",
-        "type" : "Variable",
-        "returns" : [
-
-        ],
-        "desc" : "Table containing each application's name and it's desired configuration. The",
-        "parameters" : [
-
-        ]
-      },
-      {
-        "def" : "MenuBarApps.logLevel",
-        "stripped_doc" : [
-          "MenuBarApps specific log level override, see hs.logger.setLogLevel for options."
-        ],
-        "name" : "logLevel",
-        "doc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
-        "notes" : [
-
-        ],
-        "signature" : "MenuBarApps.logLevel",
-        "type" : "Variable",
-        "returns" : [
-
-        ],
-        "desc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
-        "parameters" : [
-
-        ]
-      },
-      {
-        "def" : "MenuBarApps.logger",
-        "stripped_doc" : [
-          "Logger object used within the Spoon. Can be accessed to set the default log ",
-          "level for the messages coming from the Spoon."
-        ],
-        "name" : "logger",
-        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log \nlevel for the messages coming from the Spoon.",
-        "notes" : [
-
-        ],
-        "signature" : "MenuBarApps.logger",
-        "type" : "Variable",
-        "returns" : [
-
-        ],
-        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log",
-        "parameters" : [
-
-        ]
-      },
-      {
-        "def" : "MenuBarApps.menuBars",
-        "stripped_doc" : [
-          "Table containing references to all of the created menu bars."
-        ],
-        "name" : "menuBars",
-        "doc" : "Table containing references to all of the created menu bars.",
-        "notes" : [
-
-        ],
-        "signature" : "MenuBarApps.menuBars",
-        "type" : "Variable",
-        "returns" : [
-
-        ],
-        "desc" : "Table containing references to all of the created menu bars.",
-        "parameters" : [
-
-        ]
-      },
-      {
-        "def" : "MenuBarApps:init()",
+        "doc" : "Spoon initializer method for MenuBarApps.\n\nParameters:\n * None\n\nReturns:\n * None",
         "stripped_doc" : [
           "Spoon initializer method for MenuBarApps.",
           ""
         ],
-        "name" : "init",
-        "doc" : "Spoon initializer method for MenuBarApps.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "parameters" : [
+          " * None",
+          ""
+        ],
+        "desc" : "Spoon initializer method for MenuBarApps.",
         "notes" : [
 
         ],
@@ -212,20 +129,20 @@
         "returns" : [
           " * None"
         ],
-        "desc" : "Spoon initializer method for MenuBarApps.",
-        "parameters" : [
-          " * None",
-          ""
-        ]
+        "name" : "init",
+        "def" : "MenuBarApps:init()"
       },
       {
-        "def" : "MenuBarApps:start()",
+        "doc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
         "stripped_doc" : [
           "Spoon start method for MenuBarApps. Creates all configured menu bars.",
           ""
         ],
-        "name" : "start",
-        "doc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "parameters" : [
+          " * None",
+          ""
+        ],
+        "desc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.",
         "notes" : [
 
         ],
@@ -234,20 +151,20 @@
         "returns" : [
           " * None"
         ],
-        "desc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.",
-        "parameters" : [
-          " * None",
-          ""
-        ]
+        "name" : "start",
+        "def" : "MenuBarApps:start()"
       },
       {
-        "def" : "MenuBarApps:stop()",
+        "doc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
         "stripped_doc" : [
           "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
           ""
         ],
-        "name" : "stop",
-        "doc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "parameters" : [
+          " * None",
+          ""
+        ],
+        "desc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
         "notes" : [
 
         ],
@@ -256,11 +173,8 @@
         "returns" : [
           " * None"
         ],
-        "desc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
-        "parameters" : [
-          " * None",
-          ""
-        ]
+        "name" : "stop",
+        "def" : "MenuBarApps:stop()"
       }
     ],
     "Command" : [
@@ -269,15 +183,104 @@
     "Field" : [
 
     ],
-    "Method" : [
+    "items" : [
       {
-        "def" : "MenuBarApps:init()",
+        "doc" : "Table containing each application's name and it's desired configuration. The\nkey of each entry is the name of the App as it appears in the title bar, and\nthe value is a configuration table with the following entries:\n    * title - String with title text to display in the menu bar icon itself\n    * app - Name of the application in EnsureApp config. \n    * action - String with action to take on window when showing. See constants.",
+        "stripped_doc" : [
+          "Table containing each application's name and it's desired configuration. The",
+          "key of each entry is the name of the App as it appears in the title bar, and",
+          "the value is a configuration table with the following entries:",
+          "    * title - String with title text to display in the menu bar icon itself",
+          "    * app - Name of the application in EnsureApp config. ",
+          "    * action - String with action to take on window when showing. See constants."
+        ],
+        "parameters" : [
+
+        ],
+        "desc" : "Table containing each application's name and it's desired configuration. The",
+        "notes" : [
+
+        ],
+        "signature" : "MenuBarApps.apps",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "apps",
+        "def" : "MenuBarApps.apps"
+      },
+      {
+        "doc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
+        "stripped_doc" : [
+          "MenuBarApps specific log level override, see hs.logger.setLogLevel for options."
+        ],
+        "parameters" : [
+
+        ],
+        "desc" : "MenuBarApps specific log level override, see hs.logger.setLogLevel for options.",
+        "notes" : [
+
+        ],
+        "signature" : "MenuBarApps.logLevel",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "logLevel",
+        "def" : "MenuBarApps.logLevel"
+      },
+      {
+        "doc" : "Logger object used within the Spoon. Can be accessed to set the default log \nlevel for the messages coming from the Spoon.",
+        "stripped_doc" : [
+          "Logger object used within the Spoon. Can be accessed to set the default log ",
+          "level for the messages coming from the Spoon."
+        ],
+        "parameters" : [
+
+        ],
+        "desc" : "Logger object used within the Spoon. Can be accessed to set the default log",
+        "notes" : [
+
+        ],
+        "signature" : "MenuBarApps.logger",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "logger",
+        "def" : "MenuBarApps.logger"
+      },
+      {
+        "doc" : "Table containing references to all of the created menu bars.",
+        "stripped_doc" : [
+          "Table containing references to all of the created menu bars."
+        ],
+        "parameters" : [
+
+        ],
+        "desc" : "Table containing references to all of the created menu bars.",
+        "notes" : [
+
+        ],
+        "signature" : "MenuBarApps.menuBars",
+        "type" : "Variable",
+        "returns" : [
+
+        ],
+        "name" : "menuBars",
+        "def" : "MenuBarApps.menuBars"
+      },
+      {
+        "doc" : "Spoon initializer method for MenuBarApps.\n\nParameters:\n * None\n\nReturns:\n * None",
         "stripped_doc" : [
           "Spoon initializer method for MenuBarApps.",
           ""
         ],
-        "name" : "init",
-        "doc" : "Spoon initializer method for MenuBarApps.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "parameters" : [
+          " * None",
+          ""
+        ],
+        "desc" : "Spoon initializer method for MenuBarApps.",
         "notes" : [
 
         ],
@@ -286,20 +289,20 @@
         "returns" : [
           " * None"
         ],
-        "desc" : "Spoon initializer method for MenuBarApps.",
-        "parameters" : [
-          " * None",
-          ""
-        ]
+        "name" : "init",
+        "def" : "MenuBarApps:init()"
       },
       {
-        "def" : "MenuBarApps:start()",
+        "doc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
         "stripped_doc" : [
           "Spoon start method for MenuBarApps. Creates all configured menu bars.",
           ""
         ],
-        "name" : "start",
-        "doc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "parameters" : [
+          " * None",
+          ""
+        ],
+        "desc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.",
         "notes" : [
 
         ],
@@ -308,20 +311,20 @@
         "returns" : [
           " * None"
         ],
-        "desc" : "Spoon start method for MenuBarApps. Creates all configured menu bars.",
-        "parameters" : [
-          " * None",
-          ""
-        ]
+        "name" : "start",
+        "def" : "MenuBarApps:start()"
       },
       {
-        "def" : "MenuBarApps:stop()",
+        "doc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
         "stripped_doc" : [
           "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
           ""
         ],
-        "name" : "stop",
-        "doc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.\n\nParameters:\n * None\n\nReturns:\n * None",
+        "parameters" : [
+          " * None",
+          ""
+        ],
+        "desc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
         "notes" : [
 
         ],
@@ -330,11 +333,8 @@
         "returns" : [
           " * None"
         ],
-        "desc" : "Spoon stop method for MenuBarApps. Deletes all configured menu bars.",
-        "parameters" : [
-          " * None",
-          ""
-        ]
+        "name" : "stop",
+        "def" : "MenuBarApps:stop()"
       }
     ],
     "name" : "MenuBarApps"

--- a/init.lua
+++ b/init.lua
@@ -11,26 +11,13 @@ MenuBarApps.__index = MenuBarApps
 
 -- Metadata
 MenuBarApps.name = "MenuBarApps"
-MenuBarApps.version = "0.0.2"
+MenuBarApps.version = "0.0.3"
 MenuBarApps.author = "Adam Miller <adam@adammiller.io>"
 MenuBarApps.homepage = "https://github.com/adammillerio/MenuBarApps.spoon"
 MenuBarApps.license = "MIT - https://opensource.org/licenses/MIT"
 
--- Dependency Spoons
--- WindowCache is used for quick retrieval of windows when showing/hiding.
-WindowCache = spoon.WindowCache
-
---- MenuBarApps.action.move
---- Constant
---- Move the window to appear under the menu bar item as if it were a menu.
-
---- MenuBarApps.action.maximize
---- Constant
---- Maximize the application on the current space if it is not maximized already.
-
-local actions = {move = "move", maximize = "maximize"}
-
-for k in pairs(actions) do MenuBarApps[k] = k end -- expose actions
+-- EnsureApp is used for handling app movements when showing/hiding.
+EnsureApp = spoon.EnsureApp
 
 --- MenuBarApps.apps
 --- Variable
@@ -38,6 +25,7 @@ for k in pairs(actions) do MenuBarApps[k] = k end -- expose actions
 --- key of each entry is the name of the App as it appears in the title bar, and
 --- the value is a configuration table with the following entries:
 ---     * title - String with title text to display in the menu bar icon itself
+---     * app - Name of the application in EnsureApp config. 
 ---     * action - String with action to take on window when showing. See constants.
 MenuBarApps.apps = nil
 
@@ -57,12 +45,6 @@ MenuBarApps.logLevel = nil
 --- Table containing references to all of the created menu bars.
 MenuBarApps.menuBars = nil
 
---- MenuBarApps.menuBarOpenTimer
---- Variable
---- hs.timer for moving an app's first window after being opened via MenuBarApps.
---- This behavior can be disabled by setting disableOpen=true on the app config.
-MenuBarApps.menuBarOpenTimer = nil
-
 --- MenuBarApps:init()
 --- Method
 --- Spoon initializer method for MenuBarApps.
@@ -81,211 +63,9 @@ function MenuBarApps:_instanceCallback(callback, ...)
     return hs.fnutils.partial(callback, self, ...)
 end
 
--- Action a menu item's window. This performs whatever action is needed on an
--- app's window after being migrated to the current space.
--- Inputs are the hs.menubar, app config, the hs.application to action on, and
--- the hs.window to action on.
-function MenuBarApps:_actionMenuItem(menuBar, config, app, appWindow)
-    -- move mode - This moves the application under the menu bar item so that it
-    -- appears like a menu
-    if config.action == actions.move then
-        -- Get rect representing the frame of the app window
-        appWindowFrame = appWindow:frame()
-        -- Get rect representing the frame of the menubar item
-        appMenuBarFrame = menuBar:frame()
-
-        -- move() only moves in absolute coordinates if a rect is provided, so we
-        -- just update the appWindowFrame rect's x coordinate to be such that it is
-        -- under the menubar item, aligned to the right.
-        appWindowFrame.x = appMenuBarFrame.x -
-                               (appWindowFrame.w - appMenuBarFrame.w)
-        -- Do a similar transformation for y
-        appWindowFrame.y = appMenuBarFrame.y + appMenuBarFrame.h
-
-        -- Move the window to the desired location
-        appWindow:move(appWindowFrame)
-        -- maximize mode - This just maxmizes the app if it isn't already
-    elseif config.action == actions.maximize then
-        if appWindow:isMaximizable() then appWindow:maximize() end
-    else
-        self.logger.ef("Unknown action %s", config.action)
-    end
-
-    -- Focus the window.
-    appWindow:focus()
-end
-
--- Retrieve and move a window from an app to the currently focused space.
--- Invoked after opening the app, this retrieves the cached window for this app
--- and moves it to the currently focused space.
--- Inputs are the hs.menubar, app config, currently focused space ID, the
--- hs.application to action on.
-function MenuBarApps:_getAndMoveOpenedAppWindow(menuBar, config,
-                                                currentlyFocusedSpace, app)
-    if config.spacePrecedence then
-        -- Get the latest window specifically for this space.
-        spaceID = currentlyFocusedSpace
-    else
-        -- Otherwise just get the latest in general.
-        spaceID = nil
-    end
-
-    appWindow = WindowCache:findWindowByApp(config.app, spaceID)
-    if not appWindow then
-        self.logger.ef("No window for app %s open, cannot continue", config.app)
-        return
-    end
-
-    self:_moveOpenedAppWindow(menuBar, config, currentlyFocusedSpace, app,
-                              appWindow)
-end
-
--- Move an existing opened app window to the currently focused space.
--- Invoked directly from the menu bar handler, this will move the retrieved window
--- for this app to the currently focused space.
--- Inputs are the hs.menubar, app config, currently focused space ID, the
--- hs.application to action on, and the hs.window to action on.
-function MenuBarApps:_moveOpenedAppWindow(menuBar, config,
-                                          currentlyFocusedSpace, app, appWindow)
-    -- Move the window to the currently focused space.
-    hs.spaces.moveWindowToSpace(appWindow, currentlyFocusedSpace)
-
-    self:_actionMenuItem(menuBar, config, app, appWindow)
-end
-
--- Open a new window for the running app in the current Space.
--- Invoked from the menu bar handler for applications which have space precedence
--- enabled, this will look at the newWindowConfig for the given app to determine
--- the menu item to select which will open a new window in the current Space. It
--- will then wait for a window from this app to appear in the Space and then action
--- on it.
--- Inputs are the hs.menubar, app config, currently focused space ID, and the
--- hs.application to action on.
-function MenuBarApps:_openNewWindowInSpace(menuBar, config,
-                                           currentlyFocusedSpace, app)
-    newWindowConfig = config.newWindowConfig
-    if not newWindowConfig then
-        self.logger.ef(
-            "No newWindowConfig defined for app %s, cannot open new window in space",
-            config.app)
-        return
-    end
-
-    menuSection = newWindowConfig.menuSection
-    menuItem = newWindowConfig.menuItem
-    if menuSection and menuItem then
-        self.logger.vf("Selecting menu item '%s' in section '%s' in app '%s'",
-                       menuItem, menuSection, config.app)
-        selected = app:selectMenuItem({menuSection, menuItem})
-
-        if not selected then
-            self.logger.wf(
-                "Could not find menu item '%s' in section '%s' in app '%s'",
-                self.menuItem, self.menuSection, config.app)
-
-            return
-        end
-    end
-
-    -- Wait for a window from this app to appear in the Space and continue the
-    -- action flow.
-    self.menuBarOpenTimer = WindowCache:waitForWindowByApp(appName,
-                                                           self:_instanceCallback(
-                                                               self._getAndMoveOpenedAppWindow,
-                                                               menuBar, config,
-                                                               currentlyFocusedSpace,
-                                                               app), nil,
-                                                           currentlyFocusedSpace)
-end
-
--- Handler for a menu bar click.
--- Inputs are the hs.menubar clicked and the configured appName and config.
-function MenuBarApps:_menuBarClicked(menuBar, appName, config)
-    -- Store the focused space from before we start the action flow. This helps
-    -- when apps try to force themselves to open in another space which will change
-    -- the focused space during app open.
-    currentlyFocusedSpace = hs.spaces.focusedSpace()
-
-    -- Get app hs.window
-    self.logger.vf("Finding open window for app %s", appName)
-
-    spaceWindowNeeded = false
-    if config.spacePrecedence then
-        -- Search the Space-specific window cache for a window from this app.
-        appWindow = WindowCache:findWindowByApp(appName, currentlyFocusedSpace)
-
-        if not appWindow then
-            -- Search the main cache to find any instance of a window from this
-            -- app, so we can use it to open another one.
-            appWindow = WindowCache:findWindowByApp(appName)
-            if appWindow then
-                -- We found an existing window, and need to make a new one for
-                -- this space.
-                spaceWindowNeeded = true
-            end
-        end
-    else
-        -- Otherwise, just search the main cache for whichever window is latest.
-        appWindow = WindowCache:findWindowByApp(appName)
-    end
-
-    -- If we could not find a cached window for the app of this menu bar.
-    if not appWindow then
-        if config.disableOpen then
-            -- Open is disabled and no window, cannot continue.
-            self.logger.wf(
-                "%s is not open or hidden and open disabled, cannot continue",
-                appName)
-            return
-        else
-            -- Attempt to open app by name.
-            self.logger.vf("Opening application %s", appName)
-            app = hs.application.open(appName)
-            if not app then
-                -- No application with this name exists, cannot continue.
-                self.logger.ef("No application named %s could be opened",
-                               appName)
-                return
-            end
-
-            -- Indicate the app was opened during this run.
-            appOpened = true
-        end
-    else
-        -- If we can, get the window app's application
-        app = appWindow:application()
-        appOpened = false
-    end
-
-    if appOpened then
-        -- If this is a "fresh" open, we instead tell WindowCache to only continue
-        -- the action flow once it can find a window from the app in it. This is
-        -- implicitly Space local, so it does not need to check precedence.
-        self.menuBarOpenTimer = WindowCache:waitForWindowByApp(appName,
-                                                               self:_instanceCallback(
-                                                                   self._getAndMoveOpenedAppWindow,
-                                                                   menuBar,
-                                                                   config,
-                                                                   currentlyFocusedSpace,
-                                                                   app))
-    elseif config.spacePrecedence and spaceWindowNeeded then
-        -- If the app is running but has no window in this Space, and spacePrecedence
-        -- is enabled, then open a new window for this app in this Space.
-        self:_openNewWindowInSpace(menuBar, config, currentlyFocusedSpace, app)
-    elseif hs.window.frontmostWindow():id() ~= appWindow:id() then
-        -- If this window already exists but is not the frontmost window, then we
-        -- need to act on it, and move the window to the currently focused space.
-        self:_moveOpenedAppWindow(menuBar, config, currentlyFocusedSpace, app,
-                                  appWindow)
-    else
-        -- Otherwise just hide the app if it existed and was at the front.
-        app:hide()
-    end
-end
-
 -- Generate a sub menu for a menu bar.
--- Input is the menuConfig.
-function MenuBarApps:_createMenu(menuConfig)
+-- Input is the menuConfig and EnsureApp action specific config.
+function MenuBarApps:_createMenu(menuConfig, actionConfig)
     self.logger.vf("Creating menu with config: %s", hs.inspect(menuConfig))
     local menu = {}
 
@@ -293,15 +73,14 @@ function MenuBarApps:_createMenu(menuConfig)
         self.logger.vf("Creating menuItem config: %s", hs.inspect(config))
         local menuItem = {}
 
-        if config.action ~= "menu" then
+        if not config.menu then
             self.logger
                 .vf("Setting menu item to config: %s", hs.inspect(config))
-            menuItem.fn = self:_instanceCallback(self._menuBarClicked, menuBar,
-                                                 config.app, config)
+            menuItem.fn = EnsureApp:ensureAppCallback(config.app, actionConfig)
         else
             self.logger.vf("Creating new child menu with config: %s",
                            hs.inspect(config.menu))
-            menuItem.menu = self:_createMenu(config.menu)
+            menuItem.menu = self:_createMenu(config.menu, actionConfig)
         end
 
         menuItem.title = config.title
@@ -319,17 +98,18 @@ end
 function MenuBarApps:_createMenuBar(config)
     self.logger.vf("Creating MenuBar with config: %s", hs.inspect(config))
 
-    menuBar = hs.menubar.new()
+    local menuBar = hs.menubar.new()
 
-    if config.action ~= "menu" then
+    local actionConfig = {moveFrame = menuBar:frame()}
+
+    if not config.menu then
         self.logger.vf("(%s) Not Menu: Setting item click callback",
                        config.title)
-        menuBar:setClickCallback(self:_instanceCallback(self._menuBarClicked,
-                                                        menuBar, config.app,
-                                                        config))
+        menuBar:setClickCallback(EnsureApp:ensureAppCallback(config.app,
+                                                             actionConfig))
     else
         self.logger.vf("(%s) Menu: Generating main menu", config.title)
-        menuBar:setMenu(self:_createMenu(config.menu))
+        menuBar:setMenu(self:_createMenu(config.menu, actionConfig))
     end
 
     menuBar:setTitle(config.title)
@@ -370,8 +150,6 @@ function MenuBarApps:stop()
     self.logger.v("Stopping MenuBarApps")
 
     for i, menuBar in ipairs(self.menuBars) do menuBar:delete() end
-
-    if self.menuBarOpenTimer then self.menuBarOpenTimer:stop() end
 end
 
 return MenuBarApps

--- a/init.lua
+++ b/init.lua
@@ -100,7 +100,7 @@ function MenuBarApps:_createMenuBar(config)
 
     local menuBar = hs.menubar.new()
 
-    local actionConfig = {moveFrame = menuBar:frame()}
+    local actionConfig = {moveMenuBar = menuBar}
 
     if not config.menu then
         self.logger.vf("(%s) Not Menu: Setting item click callback",

--- a/init.lua
+++ b/init.lua
@@ -56,13 +56,6 @@ MenuBarApps.menuBars = nil
 ---  * None
 function MenuBarApps:init() self.menuBars = {} end
 
--- Utility method for having instance specific callbacks.
--- Inputs are the callback fn and any arguments to be applied after the instance
--- reference.
-function MenuBarApps:_instanceCallback(callback, ...)
-    return hs.fnutils.partial(callback, self, ...)
-end
-
 -- Generate a sub menu for a menu bar.
 -- Input is the menuConfig and EnsureApp action specific config.
 function MenuBarApps:_createMenu(menuConfig, actionConfig)
@@ -93,26 +86,72 @@ function MenuBarApps:_createMenu(menuConfig, actionConfig)
     return menu
 end
 
+-- Utility method for having instance specific callbacks.
+-- Inputs are the callback fn and any arguments to be applied after the instance
+-- reference.
+function MenuBarApps:_instanceCallback(callback, ...)
+    return hs.fnutils.partial(callback, self, ...)
+end
+
+-- Special callback for a choice based menu bar item. This behaves like a normal
+-- menu bar app for the current choice. If the Alt key is held when clicking, it
+-- will rotate the menu bar item one choice forward in the list of choices.
+-- Inputs are the entire config (with all choices), action specific configs for
+-- EnsureApp, the hs.menubar if an update is needed, and a table representing
+-- any modifiers and their state supplied by setClickCallback.
+function MenuBarApps:_choiceBasedMenuCallback(config, actionConfig, menuBar,
+                                              modifiers)
+    if modifiers.alt then
+        -- Rotate the menu bar one forward.
+        local choice = table.remove(config.choice, 1)
+        table.insert(config.choice, choice)
+
+        -- Update the title.
+        menuBar:setTitle(config.choice[1].title)
+    else
+        -- No modifier, ensure the current choice's app as normal.
+        EnsureApp:ensureApp(config.choice[1].app, actionConfig)
+    end
+end
+
 -- Utility method for creating a new menu bar and adding it to the table.
 -- Input is the menu config.
 function MenuBarApps:_createMenuBar(config)
     self.logger.vf("Creating MenuBar with config: %s", hs.inspect(config))
 
+    -- Create the new menubar item.
     local menuBar = hs.menubar.new()
 
+    -- Store the menuBar in the actionConfig, to be used with any apps which
+    -- have their EnsureApp configuration set to "move" in order to relocate the
+    -- window under the menubar.
     local actionConfig = {moveMenuBar = menuBar}
 
-    if not config.menu then
+    if config.menu then
+        -- Generate the menu that will become the menu bar's main menu.
+        self.logger.vf("(%s) Menu: Generating main menu", config.title)
+        menuBar:setMenu(self:_createMenu(config.menu, actionConfig))
+
+        menuBar:setTitle(config.title)
+    elseif config.choice then
+        -- Set the choice based menu callback and set title to first choice.
+        local choiceTitle = config.choice[1].title
+
+        self.logger.vf("(%s) Choice: Setting choice callback", choiceTitle)
+        menuBar:setClickCallback(self:_instanceCallback(
+                                     self._choiceBasedMenuCallback, config,
+                                     actionConfig, menuBar))
+
+        menuBar:setTitle(choiceTitle)
+    else
+        -- Default, set it directly to a callback to ensure the app.
         self.logger.vf("(%s) Not Menu: Setting item click callback",
                        config.title)
         menuBar:setClickCallback(EnsureApp:ensureAppCallback(config.app,
                                                              actionConfig))
-    else
-        self.logger.vf("(%s) Menu: Generating main menu", config.title)
-        menuBar:setMenu(self:_createMenu(config.menu, actionConfig))
-    end
 
-    menuBar:setTitle(config.title)
+        menuBar:setTitle(config.title)
+    end
 
     table.insert(self.menuBars, menuBar)
 end


### PR DESCRIPTION
This splits all Space/action functionality into a separate EnsureApp spoon. It also adds the ability to make multi-choice based menu bar items.